### PR TITLE
fix syntax error by using array() instead of []

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -18,14 +18,14 @@ function simple_boostrap_theme_support() {
         'default-position-x' => 'center',
         'default-attachment' => 'fixed',
     ));
-    add_theme_support('custom-header', [
+    add_theme_support('custom-header', array(
         'flex-width' => true,
         'width' => 1366,
         'flex-height' => true,
         'height' => 350,
         'header-text' => true,
         'default-text-color' => 'ffffff',
-    ]);
+    ));
     add_theme_support( 'title-tag' );
     register_nav_menus(                      // wp3+ menus
         array( 


### PR DESCRIPTION
I tried the simple bootstrap theme on my wordpress 4.7.2 installation. The following error blocks entry to the site after installation:

`Parse error: syntax error, unexpected '[' in  ... wp-content/themes/simple-bootstrap/functions.php on line 21`

I could fix (don't really know if this is a correct approach) it by replacing [] with array().